### PR TITLE
[codex] Add rrweb-snapshot utility boundaries

### DIFF
--- a/docs/adr/0001-record-source-boundary-resolver.md
+++ b/docs/adr/0001-record-source-boundary-resolver.md
@@ -1,3 +1,7 @@
 # Use a record-local source-boundary resolver
 
 `@rrweb/record` needs to build without replay-only `rrweb-snapshot` code such as `postcss`, but adding public snapshot/rebuild subpath exports would expand the package API and create compatibility obligations. We will keep the public package API unchanged and add a resolver scoped to the `@rrweb/record` build that maps selected bare package imports to local source entrypoints, restoring Rollup's module visibility for tree-shaking.
+
+## Follow-up Refactor
+
+`rrweb-snapshot` now has internal snapshot-domain and rebuild-domain utility entrypoints. These entrypoints currently re-export from the legacy shared `utils.ts` module, preserving public API compatibility while making a future split of snapshot-only, rebuild-only, and shared helpers incremental.

--- a/packages/rrweb-snapshot/src/index.ts
+++ b/packages/rrweb-snapshot/src/index.ts
@@ -16,6 +16,8 @@ import rebuild, {
   createCache,
 } from './rebuild';
 export * from './types';
+// Legacy broad export kept for compatibility. New internal imports should
+// prefer snapshot-utils.ts / rebuild-utils.ts domain entrypoints.
 export * from './utils';
 
 export {

--- a/packages/rrweb-snapshot/src/rebuild-utils.ts
+++ b/packages/rrweb-snapshot/src/rebuild-utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Rebuild-domain utility entrypoint.
+ *
+ * Intent:
+ * - Keep rebuild.ts imports explicit and isolated from snapshot-only helpers.
+ * - Serve as a stable seam for future extraction into rebuild-only modules.
+ * - Preserve current public API behavior by re-exporting from legacy utils.ts.
+ */
+export {
+  isElement,
+  Mirror,
+  isNodeMetaEqual,
+  extractFileExtension,
+} from './utils';

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -12,7 +12,7 @@ import {
   Mirror,
   isNodeMetaEqual,
   extractFileExtension,
-} from './utils';
+} from './rebuild-utils';
 import postcss from 'postcss';
 
 const tagMap: tagMap = {

--- a/packages/rrweb-snapshot/src/snapshot-utils.ts
+++ b/packages/rrweb-snapshot/src/snapshot-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Snapshot-domain utility entrypoint.
+ *
+ * Intent:
+ * - Keep snapshot.ts imports explicit and decoupled from rebuild concerns.
+ * - Serve as a stable seam for future extraction into snapshot-only modules.
+ * - Preserve current public API behavior by re-exporting from legacy utils.ts.
+ */
+export {
+  Mirror,
+  is2DCanvasBlank,
+  isElement,
+  isShadowRoot,
+  maskInputValue,
+  isNativeShadowDom,
+  stringifyStylesheet,
+  getInputType,
+  toLowerCase,
+  extractFileExtension,
+  absolutifyURLs,
+  markCssSplits,
+} from './utils';

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -30,7 +30,7 @@ import {
   extractFileExtension,
   absolutifyURLs,
   markCssSplits,
-} from './utils';
+} from './snapshot-utils';
 import dom from '@rrweb/utils';
 
 let _id = 1;

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -1,3 +1,15 @@
+/**
+ * Legacy shared utility module.
+ *
+ * This file currently contains helpers used by both snapshot and rebuild paths
+ * and is also part of the public API surface, re-exported from index.ts.
+ *
+ * Migration intent:
+ * - snapshot.ts should consume snapshot-domain helpers via snapshot-utils.ts
+ * - rebuild.ts should consume rebuild-domain helpers via rebuild-utils.ts
+ * - when safe, split internals into snapshot-only / rebuild-only / shared
+ *   modules while keeping this module as a compatibility shim for external users
+ */
 import type {
   idNodeMap,
   MaskInputFn,


### PR DESCRIPTION
## Summary
- add snapshot-domain and rebuild-domain utility entrypoints in rrweb-snapshot
- route snapshot and rebuild internals through those entrypoints without changing imported symbols
- keep the legacy utils export public and document the compatibility path

## Validation
- yarn workspace rrweb-snapshot check-types
- yarn workspace @rrweb/record build
- yarn workspace @rrweb/record test
- rg -n "postcss" packages/record/dist --glob '*.{js,cjs}' (no matches)